### PR TITLE
Update docker-image.yml

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       
       - name: Build and push image
         uses: docker/build-push-action@v2


### PR DESCRIPTION
We need to update the secrets used. That old token seems to have expired, and there is no reason to have that as a secret when actions will handle any github auth for us.